### PR TITLE
fix color scheme

### DIFF
--- a/src/gameglview.cpp
+++ b/src/gameglview.cpp
@@ -162,11 +162,11 @@ void GameGLView::resizeGL(int w, int h)
 
 float GameGLView::colors [7] [3] = {
 	{0.2, 0.2, 0.2},	// Dark grey.
-	{1.0, 0.5, 0.1},	// Orange.
 	{0.7, 0.0, 0.0},	// Red.
-	{1.0, 1.0, 0.0},	// Yellow.
-	{0.0, 0.5, 0.0},	// Green.
+	{1.0, 0.5, 0.1},	// Orange.
 	{0.0, 0.0, 0.8},	// Blue.
+	{0.0, 0.5, 0.0},	// Green.
+	{1.0, 1.0, 0.0},	// Yellow.
 	{0.9, 0.9, 0.8}		// Off-white.
 	};
 


### PR DESCRIPTION
Fix for [this bug](https://bugs.kde.org/show_bug.cgi?id=466034). Changes color scheme of the cube so it matches the original Rubik's cube